### PR TITLE
Some fixes to the positional Kalman filter / smoothing settings

### DIFF
--- a/src/tracker/psmove_kalman_filter.h
+++ b/src/tracker/psmove_kalman_filter.h
@@ -76,7 +76,6 @@ ADDCALL psmove_position_kalman_filter_update(
 	const PSMoveTrackerSmoothingSettings *tracker_settings,
 	const PSMove_3AxisVector *measured_position,	// The position measured by the sensors.
 	const PSMove_3AxisVector *acceleration_control,	// The controller-space acceleration measured on the controller.
-	const float time_delta,				// The time delta in seconds
 	PSMovePositionKalmanFilter *filter_state);
 
 #ifdef __cplusplus

--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -1918,12 +1918,13 @@ psmove_tracker_filter_3d(PSMoveTracker *tracker, TrackedController *tc)
     if (psmove_3axisvector_is_valid(&measured_position))
     {
         // Compute how long it has been since our last successful position update
-        double time_delta = psmove_timestamp_value(psmove_timestamp_diff(tracker->ts_camera_converted, tc->last_position_update));
+        double seconds_since_position_update = 
+            psmove_timestamp_value(psmove_timestamp_diff(tracker->ts_camera_converted, tc->last_position_update));
 
         // Re-initialize the positional filter if:
         // * It has been too long since the last update
         // * The position wasn't tracked the previous update
-        bool reinitialize_filter = time_delta > POSITION_FILTER_RESET_TIME || !tc->was_tracked;
+        bool reinitialize_filter = seconds_since_position_update > POSITION_FILTER_RESET_TIME || !tc->was_tracked;
 
         switch (tracker->smoothing_type)
         {
@@ -1967,7 +1968,6 @@ psmove_tracker_filter_3d(PSMoveTracker *tracker, TrackedController *tc)
                     &tracker->smoothing_settings,
                     &measured_position,
                     &acceleration_control,
-                    time_delta,
                     (PSMovePositionKalmanFilter *)tc->position_filter);
             }
 

--- a/src/unit_tests/kalman_filter_unit_test.cpp
+++ b/src/unit_tests/kalman_filter_unit_test.cpp
@@ -257,7 +257,6 @@ psmove_kalman_filter_test_sample_data()
 				&settings, 
 				&raw_position, 
 				&raw_acceleration, 
-				time_delta, 
 				position_filter);
 			
 			PSMove_3AxisVector filtered_position = psmove_position_kalman_filter_get_position(position_filter);
@@ -299,6 +298,7 @@ psmove_kalman_filter_test_sample_data()
 			}
 
 			SimTime += time_delta;
+            psmove_sleep((unsigned long)(time_delta * 1000.f));
 		}
 	}
 

--- a/src/utils/smoothing_calibration.cpp
+++ b/src/utils/smoothing_calibration.cpp
@@ -325,6 +325,9 @@ main(int arg, char** args)
 				}				
 			}
 
+            // Set the smoothing settings back to the Kalman filter before saving out to disk
+            smoothing_settings.filter_3d_type= Smoothing_Kalman;
+
 			// Save the calibration settings
 			if (psmove_tracker_save_smoothing_settings(&smoothing_settings) == PSMove_False)
 			{


### PR DESCRIPTION
- Save the Kalman filter setting when running the smoothing calibration (i.e. 'filter_3d_type')
- Move the last update timestamp for the positional Kalman filter into the kalman filter state
- Update the kalman filter unit test to run in real time.
