### PR TITLE
Fixed slow convergence in Kalman filter

### DIFF
--- a/src/tracker/psmove_tracker.c
+++ b/src/tracker/psmove_tracker.c
@@ -76,10 +76,10 @@ static const PSMoveTrackerSmoothingSettings tracker_smoothing_default_settings =
     .filter_do_2d_xy = 1,
     .filter_do_2d_r = 1,
     .filter_3d_type = Smoothing_None,
-    .acceleration_variance = 0.f,
-    .measurement_covariance = { 5.f, 0,   0,
-                                0,   5.f, 0,
-                                0,   0,  10.f}
+    .acceleration_variance = 10.f,
+    .measurement_covariance = { 0.01f, 0,   0,
+                                0,   0.01f, 0,
+                                0,   0,   1.f}
 };
 
 static const PSMoveTrackerSettings tracker_default_settings = {

--- a/src/utils/smoothing_calibration.cpp
+++ b/src/utils/smoothing_calibration.cpp
@@ -41,6 +41,7 @@
 //-- constants -----
 #define STABILIZE_WAIT_TIME_MS 1000
 #define DESIRED_TRACKER_SAMPLE_COUNT 100
+#define GRAVITY_IN_CM_PER_SEC_PER_SEC 980.665f //cm/s^2
 
 enum eCalibrationState
 {
@@ -171,7 +172,7 @@ main(int arg, char** args)
 			LOG_MESSAGE("Measurement will start once the controller is aligned with gravity and stable.\n");
 
 			int stable_start_time = psmove_util_get_ticks();
-			PSMove_3AxisVector accelerometer_samples[DESIRED_TRACKER_SAMPLE_COUNT]; // in g/s^2
+			PSMove_3AxisVector accelerometer_samples[DESIRED_TRACKER_SAMPLE_COUNT]; // in cm/s^2
 			PSMove_3AxisVector position_samples[DESIRED_TRACKER_SAMPLE_COUNT]; // in cm
 			int sample_count = 0;
 
@@ -205,6 +206,10 @@ main(int arg, char** args)
 					&accelerometer_samples[sample_count].x, 
 					&accelerometer_samples[sample_count].y, 
 					&accelerometer_samples[sample_count].z);
+
+                // Convert from g to cm/S^2
+                accelerometer_samples[sample_count]=
+                    psmove_3axisvector_scale(&accelerometer_samples[sample_count], GRAVITY_IN_CM_PER_SEC_PER_SEC);
 
 				// Render the frame to a window
 				void *frame = psmove_tracker_get_frame(tracker);


### PR DESCRIPTION
The acceleration variance was not computed correctly in the calibration app. It needed to be in units of cm/s^2 and not the raw 'g' units given by the controller.
