### PR TITLE
Fixed two issues with psmove_tracker_filter_3d:

### DIFF
--- a/examples/c/test_fusion.c
+++ b/examples/c/test_fusion.c
@@ -125,14 +125,15 @@ int main(int arg, char** args) {
     // You can also add an additional transform now or at any point
     float add_pos[3] = { 0, 0, 0 };
     float add_quat[4] = { 1, 0, 0, 0 };
-    psmove_fusion_update_transform(fusion, add_pos, add_quat);
+    float add_scale[3] = { 1, 1, 1 };
+    psmove_fusion_update_transform(fusion, add_pos, add_quat, add_scale);
 
     // For example, if you have a dk2_camera_pose as follows:
     // (px, py, pz, qw, qx, qy, qz)
     // 1.7896  -13.1017  -86.5323    0.9998    0.0041   -0.0158    0.0108
     //add_pos[0] = 1.7896; add_pos[1] = -13.1017; add_pos[2] = -86.5323;
     //add_quat[0] = 0.9998; add_quat[1] = 0.0041; add_quat[2] = -0.0158; add_quat[3] = 0.0108;
-    //psmove_fusion_update_transform(fusion, add_pos, add_quat);
+    //psmove_fusion_update_transform(fusion, add_pos, add_quat, add_scale);
 
     while ((cvWaitKey(1) & 0xFF) != 27) {
         psmove_tracker_update_image(tracker);

--- a/include/psmove_fusion.h
+++ b/include/psmove_fusion.h
@@ -59,9 +59,11 @@ typedef struct _PSMoveFusion PSMoveFusion; /*!< Handle to a PS Move Fusion objec
 *                   additional transform translation
 * \param quat_wxyz  A pointer to a float[4] array representing the
 *                   additional transform quaternion
+* \param scale_xyz  A pointer to a float[3] array representing the
+*                   additional transform scale
 **/
 ADDAPI void
-ADDCALL psmove_fusion_update_transform(PSMoveFusion *fusion, float *pos_xyz, float *quat_wxyz);
+ADDCALL psmove_fusion_update_transform(PSMoveFusion *fusion, float *pos_xyz, float *quat_wxyz, float *scale_xyz);
 
 /**
 * \brief Resets both physical_xf and total_xf to identity matrix.

--- a/src/tracker/psmove_fusion.cpp
+++ b/src/tracker/psmove_fusion.cpp
@@ -108,13 +108,15 @@ print_mat4(glm::mat4 in)
 }
 
 void
-psmove_fusion_update_transform(PSMoveFusion *fusion, float *pos_xyz, float *quat_wxyz)
+psmove_fusion_update_transform(PSMoveFusion *fusion, float *pos_xyz, float *quat_wxyz, float *scale_xyz)
 {
     glm::vec3 position(pos_xyz[0], pos_xyz[1], pos_xyz[2]);
     glm::quat quaternion(quat_wxyz[0], quat_wxyz[1], quat_wxyz[2], quat_wxyz[3]);
+    glm::vec3 scale(scale_xyz[0], scale_xyz[1], scale_xyz[2]);
     glm::mat4 quatmat = glm::mat4_cast(quaternion);
     glm::mat4 posmat = glm::translate(glm::mat4(), position);
-    fusion->total_xf = posmat * quatmat * fusion->physical_xf;
+    glm::mat4 scalemat = glm::scale(glm::mat4(), scale);
+    fusion->total_xf = posmat * quatmat * scalemat * fusion->physical_xf;
     /*
     printf("fusion->total_xf = posmat * quatmat * fusion->physical_xf;\n");
     printf("posmat:\n");


### PR DESCRIPTION
- Kalman filter case wasn't getting proper init method called
- Some code paths can call psmove_tracker_filter_3d() before the filter has been initialized. Initialize the filters in this case.
